### PR TITLE
Fixed error "Incorrect syntax near 'GO'."

### DIFF
--- a/docs/relational-databases/security/tutorial-creating-using-indexes-on-enclave-enabled-columns-using-randomized-encryption.md
+++ b/docs/relational-databases/security/tutorial-creating-using-indexes-on-enclave-enabled-columns-using-randomized-encryption.md
@@ -81,7 +81,7 @@ In this step, you'll create and test an index on an encrypted column. You'll be 
 
    CREATE INDEX IX_LastName ON [Employees] ([LastName])
    INCLUDE ([EmployeeID], [FirstName], [SSN], [Salary]);
-   GO;
+   GO
    ```
 
 1. Run a rich query on the **LastName** column and verify SQL Server uses the index when executing the query.
@@ -148,7 +148,7 @@ In this step, you'll create an index on an encrypted column, pretending to be tw
 
         CREATE INDEX IX_LastName ON [Employees] ([LastName])
         INCLUDE ([EmployeeID], [FirstName], [SSN], [Salary]);
-        GO;
+        GO
         ```
 
 1. As a data owner, run a rich query on the **LastName** column and verify SQL Server uses the index when executing the query.


### PR DESCRIPTION
Sample script had a ';' after the GO key word that caused 

```
Msg 102, Level 15, State 1, Line 6
Incorrect syntax near 'GO'.
````
Fixed it by removing the redundant ';'.